### PR TITLE
keystores: fix index out of range when --source-min greater than 0

### DIFF
--- a/main.go
+++ b/main.go
@@ -417,7 +417,7 @@ func selectVals(sourceMnemonic string,
 				return fmt.Errorf("account %s cannot be derived, continuing to next account", valAccPath)
 			}
 			pubkey := narrowedPubkey(hex.EncodeToString(a.PublicKey().Marshal()))
-			if err := output.InsertAccount(a, insecure, idx); err != nil {
+			if err := output.InsertAccount(a, insecure, idx-minAcc); err != nil {
 				if err.Error() == fmt.Sprintf("account with name \"%s\" already exists", pubkey) {
 					fmt.Printf("Account with pubkey %s already exists in output wallet, skipping it\n", pubkey)
 				} else {


### PR DESCRIPTION
Fixes the following panic when setting  `--source-min` greater than `0`:

```
go run main.go keystores \                                                                                                                                                                                                      
    --insecure \                                                                                                                                                                                                                                                                     
    --prysm-pass="prysm" \                                                                                                                                                                                                                                                           
    --out-loc="validator_prep/test" \                                                                                                                                                                                                                                                
    --source-max="20" \                                                                                                                                                                                                                                                              
    --source-min="1" \                                                                                                                                                                                                                                                               
    --source-mnemonic="$VALIDATORS_MNEMONIC_2"                                                                                                                                                                                                                                       
panic: runtime error: invalid memory address or nil pointer dereference                                                                                                                                                                                                              
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x651ab8]                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                     
goroutine 1 [running]:                                                                                                                                                                                                                                                               
main.(*KeyEntry).PubHex(0xc0005320c0)                                                                                                                                                                                                                                                
        /home/rafael/code/ethereum/eth2-val-tools/main.go:112 +0x18                                                                                                                                                                                                                  
main.(*WalletWriter).WriteOutputs(0xc00009ccc0, {0x7ffe4c59ba47, 0x13}, {0x7ffe4c59ba37, 0x5})                                                                                                                                                                                       
        /home/rafael/code/ethereum/eth2-val-tools/main.go:328 +0x952                                                                                                                                                                                                                 
main.keystoresCommand.func1(0xc0000c0a00, {0xc0000b08a0, 0x6, 0x6})                                                                                                                                                                                                                  
        /home/rafael/code/ethereum/eth2-val-tools/main.go:379 +0x14f                                                                                                                                                                                                                 
github.com/spf13/cobra.(*Command).execute(0xc0000c0a00, {0xc0000b07e0, 0x6, 0x6})                                                                                                                                                                                                    
        /home/rafael/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:856 +0x5f8                                                                                                                                                                                                  
github.com/spf13/cobra.(*Command).ExecuteC(0xc0000c0780)                                                                                                                                                                                                                             
        /home/rafael/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:960 +0x3ad                                                                                                                                                                                                  
github.com/spf13/cobra.(*Command).Execute(...)                                                                                                                                                                                                                                       
        /home/rafael/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:897                                                                                                                                                                                                         
main.main()                                                                                                                                                                                                                                                                          
        /home/rafael/code/ethereum/eth2-val-tools/main.go:605 +0x185                                                                                                                                                                                                                 
exit status 2 
```