### PR TITLE
Lodestar 0x prefix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/z3n-chada/eth2-val-tools
+module github.com/protolambda/eth2-val-tools
 
 go 1.14
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/protolambda/eth2-val-tools
+module github.com/z3n-chada/eth2-val-tools
 
 go 1.14
 

--- a/main.go
+++ b/main.go
@@ -316,7 +316,7 @@ func (ww *WalletWriter) WriteOutputs(fpath string, prysmPass string) error {
 			e := k
 			g.Go(func() error {
 				pubHex := e.PubHexBare()
-				return ioutil.WriteFile(filepath.Join(secretsDirPath, pubHex), []byte(e.passphrase), 0644)
+				return ioutil.WriteFile(filepath.Join(secretsDirPath, "0x" + pubHex), []byte(e.passphrase), 0644)
 			})
 
 		}


### PR DESCRIPTION
adds the 0x prefix to lodestar-secrets. This is technically redundant considering we could use the lighthouse secrets dir, but this fix allows it to work in old workflows without changing the logic.