### PR TITLE
feat: add 0x03 builder withdrawal credentials (ePBS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Flags:
 
 ### `deposit-data`
 
-To quickly generate a list of deposit datas for a range of accounts. Supports different withdrawal credential types (0x00, 0x01, 0x02).
+To quickly generate a list of deposit datas for a range of accounts. Supports different withdrawal credential types (0x00, 0x01, 0x02, 0x03).
 
 ```
 Create deposit data for the given range of validators with configurable withdrawal credentials. 1 json-encoded deposit data per line.
@@ -54,8 +54,8 @@ Flags:
       --source-max uint                      Maximum validator index in HD path range (excl.)
       --source-min uint                      Minimum validator index in HD path range (incl.)
       --validators-mnemonic string           Mnemonic to use for validators.
-      --withdrawal-address string            Withdrawal address for 0x01 and 0x02 withdrawal credentials. Hex encoded with prefix.
-      --withdrawal-credentials-type string   Type of withdrawal credentials: 0x00 (BLS), 0x01 (execution address), or 0x02 (compounding) (default "0x00")
+      --withdrawal-address string            Withdrawal address for 0x01, 0x02, and 0x03 withdrawal credentials. Hex encoded with prefix.
+      --withdrawal-credentials-type string   Type of withdrawal credentials: 0x00 (BLS), 0x01 (execution address), 0x02 (compounding), or 0x03 (builder) (default "0x00")
       --withdrawals-mnemonic string          Mnemonic to use for BLS withdrawal creds. Only required for 0x00 withdrawal credentials.
 ```
 
@@ -64,6 +64,7 @@ Flags:
 - **0x00 (BLS)**: Traditional BLS withdrawal credentials (default behavior). Requires `--withdrawals-mnemonic`.
 - **0x01 (Execution Address)**: Direct execution address withdrawal credentials. Requires `--withdrawal-address`.
 - **0x02 (Compounding)**: Compounding withdrawal credentials for future EIP-7002 support. Requires `--withdrawal-address`.
+- **0x03 (Builder)**: Builder withdrawal credentials for ePBS (EIP-7732). Requires `--withdrawal-address`.
 
 #### Examples
 
@@ -95,6 +96,16 @@ eth2-val-tools deposit-data \
   --source-min=0 --source-max=5 \
   --fork-version=0x00000000 \
   --withdrawal-credentials-type=0x02
+```
+
+Builder withdrawal credentials (ePBS):
+```shell script
+eth2-val-tools deposit-data \
+  --validators-mnemonic="abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about" \
+  --withdrawal-address=0x742d35Cc6634C0532925a3b8D73e684B8F8832B2 \
+  --source-min=0 --source-max=5 \
+  --fork-version=0x00000000 \
+  --withdrawal-credentials-type=0x03
 ```
 
 ### `bls-address-change`

--- a/main.go
+++ b/main.go
@@ -591,7 +591,7 @@ func createDepositDatasCmd() *cobra.Command {
 
 			valSeed, err := mnemonicToSeed(validatorsMnemonic)
 			checkErr(err, "bad validator mnemonic")
-			
+
 			var withdrSeed []byte
 			if withdrawalCredType == "0x00" {
 				if withdrawalsMnemonic == "" {
@@ -649,8 +649,17 @@ func createDepositDatasCmd() *cobra.Command {
 					checkErr(execAddr.UnmarshalText([]byte(withdrawalAddr)), "cannot decode withdrawal address")
 					withdrCreds[0] = 0x02
 					copy(withdrCreds[12:], execAddr[:])
+				case "0x03":
+					// Builder withdrawal credentials (ePBS / EIP-7732)
+					if withdrawalAddr == "" {
+						checkErr(errors.New("withdrawal-address is required when using 0x03 withdrawal credentials"), "")
+					}
+					var execAddr common.Eth1Address
+					checkErr(execAddr.UnmarshalText([]byte(withdrawalAddr)), "cannot decode withdrawal address")
+					withdrCreds[0] = 0x03
+					copy(withdrCreds[12:], execAddr[:])
 				default:
-					checkErr(fmt.Errorf("invalid withdrawal credential type: %s (must be 0x00, 0x01, or 0x02)", withdrawalCredType), "")
+					checkErr(fmt.Errorf("invalid withdrawal credential type: %s (must be 0x00, 0x01, 0x02, or 0x03)", withdrawalCredType), "")
 				}
 
 				data := common.DepositData{
@@ -691,8 +700,8 @@ func createDepositDatasCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&validatorsMnemonic, "validators-mnemonic", "", "Mnemonic to use for validators.")
 	cmd.Flags().StringVar(&withdrawalsMnemonic, "withdrawals-mnemonic", "", "Mnemonic to use for BLS withdrawal creds. Only required for 0x00 withdrawal credentials.")
-	cmd.Flags().StringVar(&withdrawalAddr, "withdrawal-address", "", "Withdrawal address for 0x01 and 0x02 withdrawal credentials. Hex encoded with prefix.")
-	cmd.Flags().StringVar(&withdrawalCredType, "withdrawal-credentials-type", "0x00", "Type of withdrawal credentials: 0x00 (BLS), 0x01 (execution address), or 0x02 (compounding)")
+	cmd.Flags().StringVar(&withdrawalAddr, "withdrawal-address", "", "Withdrawal address for 0x01, 0x02, and 0x03 withdrawal credentials. Hex encoded with prefix.")
+	cmd.Flags().StringVar(&withdrawalCredType, "withdrawal-credentials-type", "0x00", "Type of withdrawal credentials: 0x00 (BLS), 0x01 (execution address), 0x02 (compounding), or 0x03 (builder)")
 	cmd.Flags().Uint64Var(&accountMin, "source-min", 0, "Minimum validator index in HD path range (incl.)")
 	cmd.Flags().Uint64Var(&accountMax, "source-max", 0, "Maximum validator index in HD path range (excl.)")
 	cmd.Flags().Uint64Var(&amountGwei, "amount", uint64(configs.Mainnet.MAX_EFFECTIVE_BALANCE), "Amount to deposit, in Gwei")


### PR DESCRIPTION
## Summary
- Adds support for `0x03` (`BUILDER_WITHDRAWAL_PREFIX`) withdrawal credentials type to the `deposit-data` command
- Follows the [Gloas consensus spec](https://github.com/ethereum/consensus-specs/blob/dev/specs/gloas/beacon-chain.md) for enshrined Proposer-Builder Separation (EIP-7732)
- Same credential format as 0x01/0x02: prefix byte + 11 zero bytes + 20-byte execution address, requires `--withdrawal-address`

## Usage
```bash
eth2-val-tools deposit-data \
  --validators-mnemonic="..." \
  --withdrawal-address=0x742d35Cc6634C0532925a3b8D73e684B8F8832B2 \
  --source-min=0 --source-max=5 \
  --fork-version=0x00000000 \
  --withdrawal-credentials-type=0x03
```

## Test plan
- [x] Verify `--withdrawal-credentials-type=0x03` generates deposit data with `03` prefix in withdrawal credentials
- [x] Verify `--withdrawal-credentials-type=0x03` without `--withdrawal-address` returns an error
- [x] Verify existing 0x00, 0x01, 0x02 types still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)